### PR TITLE
Add server and file change watcher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2==2.10.1
 markdown2==2.3.5
+watchdog==0.9.0

--- a/volta.py
+++ b/volta.py
@@ -4,10 +4,15 @@ import sys
 import time
 import re
 import argparse
+import multiprocessing
+import time
 from urllib.parse import quote
 from datetime import datetime
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from jinja2 import Environment, FileSystemLoader
 from markdown2 import markdown
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
 
 
 
@@ -264,11 +269,54 @@ def build_site():
 
 
 
+def run_server(output_dir, port):
+  print('Starting server for {} on http://localhost:{}'.format(output_dir, port))
+  os.chdir(output_dir)
+  httpd = HTTPServer(('', port), SimpleHTTPRequestHandler)
+  httpd.serve_forever()
+
+
+
+class RebuildEventHandler(FileSystemEventHandler):
+  def on_any_event(self, event):
+    print('Event type {} for {}', event.event_type, event.src_path)
+    build_site()
+
+
+
+def start_serve():
+  server_process = multiprocessing.Process(target=run_server,
+                                           args=(CONFIG['OUTPUT_DIR'], 8000))
+  server_process.start()
+
+  path = CONFIG['CONTENTS_DIR']
+  observer = Observer()
+  observer.schedule(RebuildEventHandler(), path, recursive=True)
+  observer.start()
+
+  try:
+    while True:
+      time.sleep(1)
+  except KeyboardInterrupt:
+    print('Keyboard interrupt: shutting down')
+  finally:
+    server_process.terminate()
+    observer.stop()
+  observer.join()
+  server_process.join()
+
+
+
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument("-r", "--rebuild", help="Rebuilds the entire site", action="store_true")
+  parser.add_argument("-s", "--serve", help="Build and serve the site",
+                      action="store_true")
   args = parser.parse_args()
   check_config()
   if args.rebuild:
     CONFIG["LAST_UPDATED"] = 0
   build_site()
+
+  if args.serve:
+    start_serve()


### PR DESCRIPTION
This change adds a mode which runs a server to serve the output
directory and simultaneously builds whenever files in the content
directory change.